### PR TITLE
fix: broader error checking for deployments_triage

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,11 +56,14 @@ func InitClient() *kubernetes.Clientset {
 
 	flag.Parse()
 
-	config = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
                 &clientcmd.ClientConfigLoadingRules{ExplicitPath: *kubeconfig},
                 &clientcmd.ConfigOverrides{
-                        CurrentContext: *context,
+                        CurrentContext: *kubecontext,
                 }).ClientConfig()
+	if err != nil {
+		panic(err.Error())
+	}
 	
 	csBackup, err := getClientSetFromConfig(config)
 	if err != nil {

--- a/pkg/triage/deployments_triage.go
+++ b/pkg/triage/deployments_triage.go
@@ -1,6 +1,7 @@
 package triage
 
 import (
+	"strings"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -12,7 +13,7 @@ func OrphanedDeployments(kubeCli *kubernetes.Clientset, namespace string) (*Tria
 	listOfTriages := make([]string, 0)
 	deployments, err := kubeCli.ExtensionsV1beta1().Deployments(namespace).List(v1.ListOptions{})
 	if err != nil {
-		if err.Error() != KUBE_RESOURCE_NOT_FOUND {
+		if ! strings.Contains(err.Error(), KUBE_RESOURCE_NOT_FOUND) {
 			return nil, err
 		}
 	}
@@ -31,7 +32,7 @@ func LeftOverDeployments(kubeCli *kubernetes.Clientset, namespace string) (*Tria
 	listOfTriages := make([]string, 0)
 	deployments, err := kubeCli.ExtensionsV1beta1().Deployments(namespace).List(v1.ListOptions{})
 	if err != nil {
-		if err.Error() != KUBE_RESOURCE_NOT_FOUND {
+		if ! strings.Contains(err.Error(), KUBE_RESOURCE_NOT_FOUND) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
# Problem

Deployments triage fails to successfully capture and ignore `RESOURCE_NOT_FOUND` errors.

# Solution

Use `strings.Contains` to successfully partial match the error string.

# Result

Evaluation successfully completes.

# Testing

## Tested against a microk8s cluster

```
 mark   master  …  workspace  emirozer  kubectl-doctor.git  kubectl get nodes                                                                                                                            
NAME       STATUS   ROLES    AGE     VERSION
rpi4-4gb   Ready    <none>   7d1h    v1.22.3-3+64e63223b19811
allanon    Ready    <none>   7d      v1.22.3-3+9ec7c40ec93c73
shannara   Ready    <none>   6d23h   v1.22.3-3+9ec7c40ec93c73
macmini    Ready    <none>   7d      v1.22.3-3+9ec7c40ec93c73
 mark   master  …  workspace  emirozer  kubectl-doctor.git    
```

## doctor v.0.3.0 output

```
 mark   master  …  workspace  emirozer  kubectl-doctor.git  1  kubectl doctor                                                                                                                           
INFO[0000] Going for a full scan as no flags are set!   
INFO[0000] Retrieving necessary clientset for targeted k8s cluster. 
INFO[0000]                                              
INFO[0000] Fetched namespaces: [kube-system kube-public kube-node-lease default metallb-system monitoring external-mdns airconnect marax cert-manager homebridge tailscale ingress plex network-ups-tools adguard-home vbulletin istio-system dex argocd] 
INFO[0000]                                              
WARN[0000] doctor's client-go version: 11.0.0 is not fully compatible with your k8s server version: 1.22.3-3+64e63223b19811 
WARN[0000] https://github.com/kubernetes/client-go#compatibility-matrix 
WARN[0000] doctor run will be based on best-effort delivery 
INFO[0000] Starting triage of cluster crucial component health checks. 
INFO[0000] Starting triage of nodes that form the cluster. 
INFO[0000] Starting triage of cluster-wide Endpoints resources. 
INFO[0000] Starting triage of cluster-wide pvc resources. 
INFO[0000] Starting triage of cluster-wide pv resources. 
INFO[0000] Starting triage of deployment resources across cluster 
Error from server (NotFound): the server could not find the requested resource (get deployments.extensions)
 mark   master  …  workspace  emirozer  kubectl-doctor.git  1  krew info doctor                                                                                                                         
NAME: doctor
INDEX: default
URI: https://github.com/emirozer/kubectl-doctor/releases/download/0.3.0/kubectl-doctor_darwin_amd64.zip
SHA256: c07c4a2ae741e2dbcd0fc4c9e543ca6558877ee74a16e9d9c129a6ffc834f1a2
VERSION: v0.3.0
HOMEPAGE: https://github.com/emirozer/kubectl-doctor
DESCRIPTION: 
This plugin is inspired by brew doctor.
It will scan the active kube-context for anomalies or
useful action points that it can report back to you.
This plugin does not change any state or configuration.

Please check the repository for an example report:

* https://github.com/emirozer/kubectl-doctor

CAVEATS:
\
 | This plugin needs higher privileges on core API group.
 | Potentially a ClusterRole that can get cluster-scoped resources.
 | Such as nodes / all namespaces etc.
/
 mark   master  …  workspace  emirozer  kubectl-doctor.git   
```

## With the fix applied

```
 mark   master  …  workspace  emirozer  kubectl-doctor.git  go run cmd/kubectl-doctor.go                                                                                                                 
INFO[0000] Going for a full scan as no flags are set!   
INFO[0000] Retrieving necessary clientset for targeted k8s cluster. 
INFO[0000]                                              
INFO[0000] Fetched namespaces: [kube-system kube-public kube-node-lease default metallb-system monitoring external-mdns airconnect marax cert-manager homebridge tailscale ingress plex network-ups-tools adguard-home vbulletin istio-system dex argocd] 
INFO[0000]                                              
WARN[0000] doctor's client-go version: 11.0.0 is not fully compatible with your k8s server version: 1.22.3-3+64e63223b19811 
WARN[0000] https://github.com/kubernetes/client-go#compatibility-matrix 
WARN[0000] doctor run will be based on best-effort delivery 
INFO[0000] Starting triage of cluster crucial component health checks. 
INFO[0000] Starting triage of nodes that form the cluster. 
INFO[0000] Starting triage of cluster-wide Endpoints resources. 
INFO[0000] Starting triage of cluster-wide pvc resources. 
INFO[0000] Starting triage of cluster-wide pv resources. 
INFO[0000] Starting triage of deployment resources across cluster 
INFO[0006] Starting triage of replicasets resources across cluster 
INFO[0012] Starting triage of cronjob resources across cluster 
INFO[0014] Starting triage of ingress resources across cluster 
INFO[0016] Triage report coming up in yaml format:      

---
 TriageReport:
- Resource: Endpoints
  AnomalyType: Found orphaned endpoints!
  Anomalies:
  - nginx
  - sealed-secrets-controller
  - demo

 mark   master  …  workspace  emirozer  kubectl-doctor.git   
```
